### PR TITLE
Unroll deposit bit plane loop

### DIFF
--- a/src/cuda_zfp/decode.cuh
+++ b/src/cuda_zfp/decode.cuh
@@ -127,8 +127,12 @@ void decode_ints(BlockReader<Size> &reader, uint &max_bits, UInt *data)
       for (; n < (Size - 1) && bits && (bits--, !reader.read_bit()); n++);
     
     // deposit bit plane
+#if (CUDART_VERSION < 8000)
     #pragma unroll
-    for (int i = 0; x; i++, x >>= 1)
+#else
+    #pragma unroll Size
+#endif
+    for (int i = 0; i < Size; i++, x >>= 1)
     {
       data[i] += (UInt)(x & 1u) << k;
     }

--- a/src/inline/bitstream.c
+++ b/src/inline/bitstream.c
@@ -107,6 +107,9 @@ The following assumptions and restrictions apply:
   #define inline_
 #endif
 
+/* satisfy compiler when args unused */
+#define unused_(x) ((void)(x))
+
 /* bit stream word/buffer type; granularity of stream I/O operations */
 #ifdef BIT_STREAM_WORD_TYPE
   /* may be 8-, 16-, 32-, or 64-bit unsigned integer type */
@@ -187,6 +190,7 @@ stream_stride_block(const bitstream* s)
 #ifdef BIT_STREAM_STRIDED
   return s->mask + 1;
 #else
+  unused_(s);
   return 1;
 #endif
 }
@@ -198,6 +202,7 @@ stream_stride_delta(const bitstream* s)
 #ifdef BIT_STREAM_STRIDED
   return s->delta / (s->mask + 1);
 #else
+  unused_(s);
   return 0;
 #endif
 }
@@ -448,3 +453,5 @@ stream_clone(const bitstream* s)
     *c = *s;
   return c;
 }
+
+#undef unused_

--- a/tests/src/endtoend/zfpEndtoendBase.c
+++ b/tests/src/endtoend/zfpEndtoendBase.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string.h>
 
-#if defined(__linux__) || defined(_WIN32)
+#if defined(__unix__) || defined(_WIN32)
   #include <time.h>
 #elif defined(__MACH__)
   #include <mach/mach_time.h>
@@ -64,7 +64,7 @@ struct setupVars {
   UInt decompressedChecksum;
 
   // timer
-#if defined(__linux__) || defined(_WIN32)
+#if defined(__unix__) || defined(_WIN32)
   clock_t timeStart, timeEnd;
 #elif defined(__MACH__)
   uint64_t timeStart, timeEnd;
@@ -463,7 +463,7 @@ startTimer(void **state)
   struct setupVars *bundle = *state;
 
   // set up timer
-#if defined(__linux__) || defined(_WIN32)
+#if defined(__unix__) || defined(_WIN32)
   bundle->timeStart = clock();
 #elif defined(__MACH__)
   bundle->timeStart = mach_absolute_time();
@@ -479,7 +479,7 @@ stopTimer(void **state)
   double time;
 
   // stop timer, compute elapsed time
-#if defined(__linux__) || defined(_WIN32)
+#if defined(__unix__) || defined(_WIN32)
   bundle->timeEnd = clock();
   time = (double)((bundle->timeEnd) - (bundle->timeStart)) / CLOCKS_PER_SEC;
 #elif defined(__MACH__)


### PR DESCRIPTION
Setting the bound static prevents Warp divergence and speeds up the writing.
CUDA 8 supports specifying the unrolling factor which is done in other functions of the CUDA implementation as well.