### PR TITLE
Use actual decompressed size instead of estimated size.

### DIFF
--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -213,7 +213,7 @@ Word *setup_device_stream(zfp_stream *stream,const zfp_field *field)
   } 
 
   Word *d_stream = NULL;
-  // TODO: we we have a real stream we can just ask it how big it is
+  size_t size = stream_capacity(stream->stream);
   size_t max_size = zfp_stream_maximum_size(stream, field);
   cudaMalloc(&d_stream, max_size);
   cudaMemcpy(d_stream, stream->stream->begin, max_size, cudaMemcpyHostToDevice);


### PR DESCRIPTION
I'm not sure what would happen if the stream contains a ZFP header. Note that ZFP read/write header is not working in the CUDA version of ZFP.